### PR TITLE
POC: Ruby aliasing fix

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
@@ -62,7 +62,7 @@ public class DynamicLangApiMethodTransformer {
     } else {
       apiMethod.type(ClientMethodType.OptionalArrayMethod);
     }
-    apiMethod.apiClassName(namer.getApiWrapperClassName(context.getInterfaceConfig()));
+    apiMethod.apiClassName(namer.getPrefixedApiWrapperClassName(context.getInterfaceConfig()));
     apiMethod.apiVariableName(namer.getApiWrapperVariableName(context.getInterfaceConfig()));
     apiMethod.apiModuleName(namer.getApiWrapperModuleName());
     InitCodeOutputType initCodeOutputType =

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -145,7 +145,7 @@ public class InitCodeTransformer {
       SingleResourceNameConfig resourceNameConfig =
           context.getSingleResourceNameConfig(fieldNamePattern.getValue());
       String apiWrapperClassName =
-          context.getNamer().getApiWrapperClassName(context.getInterfaceConfig());
+          context.getNamer().getPrefixedApiWrapperClassName(context.getInterfaceConfig());
       InitValueConfig initValueConfig =
           InitValueConfig.create(apiWrapperClassName, resourceNameConfig);
       mapBuilder.put(fieldNamePattern.getKey(), initValueConfig);
@@ -385,7 +385,7 @@ public class InitCodeTransformer {
         FormattedInitValueView.Builder initValue = FormattedInitValueView.newBuilder();
 
         initValue.apiWrapperName(
-            context.getNamer().getApiWrapperClassName(context.getInterfaceConfig()));
+            context.getNamer().getPrefixedApiWrapperClassName(context.getInterfaceConfig()));
         initValue.formatFunctionName(
             context
                 .getNamer()

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -152,6 +152,16 @@ public class SurfaceNamer extends NameFormatterDelegator {
     return qualifiedName(namePath.withoutHead());
   }
 
+  /** The qualified namespace of the package of a protofile */
+  public String getNamespace(ProtoFile file) {
+    return qualifiedName(typeNameConverter.getNamePath(modelTypeFormatter.getFullNameFor(file)));
+  }
+
+  /** The nickname of the qualified namespace of a protofile. */
+  public String getNamespaceNickname(ProtoFile file) {
+    return getNotImplementedString("SurfaceNamer.getNamespaceNickname");
+  }
+
   /** The modules of the package. */
   public ImmutableList<String> getApiModules() {
     return ImmutableList.<String>of();
@@ -1243,5 +1253,9 @@ public class SurfaceNamer extends NameFormatterDelegator {
   public String getOptionalFieldDefaultValue(
       FieldConfig fieldConfig, MethodTransformerContext context) {
     return getNotImplementedString("SurfaceNamer.getOptionalFieldDefaultValue");
+  }
+
+  public String getPrefixedApiWrapperClassName(InterfaceConfig interfaceConfig) {
+    return getApiWrapperClassName(interfaceConfig);
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTestTransformer.java
@@ -121,7 +121,8 @@ public class RubyGapicSurfaceTestTransformer implements ModelToViewTransformer {
 
     OptionalArrayMethodView.Builder apiMethodView = initialApiMethodView.toBuilder();
 
-    InitCodeTransformer initCodeTransformer = new InitCodeTransformer();
+    InitCodeTransformer initCodeTransformer =
+        new InitCodeTransformer(new RubyImportSectionTransformer());
     InitCodeView initCodeView =
         initCodeTransformer.generateInitCode(
             context, testCaseTransformer.createSmokeTestInitContext(context));
@@ -138,7 +139,7 @@ public class RubyGapicSurfaceTestTransformer implements ModelToViewTransformer {
         apiConfig,
         new ModelTypeTable(
             new RubyTypeTable(apiConfig.getPackageName()),
-            new RubyModelTypeNameConverter(apiConfig.getPackageName())),
+            new RubySampleModelTypeNameConverter(apiConfig.getPackageName())),
         new RubySurfaceNamer(apiConfig.getPackageName()),
         new RubyFeatureConfig());
   }

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
@@ -26,6 +26,8 @@ import com.google.api.codegen.transformer.DynamicLangApiMethodTransformer;
 import com.google.api.codegen.transformer.FeatureConfig;
 import com.google.api.codegen.transformer.FileHeaderTransformer;
 import com.google.api.codegen.transformer.GrpcStubTransformer;
+import com.google.api.codegen.transformer.ImportSectionTransformer;
+import com.google.api.codegen.transformer.InitCodeTransformer;
 import com.google.api.codegen.transformer.ModelToViewTransformer;
 import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.PageStreamingTransformer;
@@ -56,10 +58,13 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer {
 
   private final GapicCodePathMapper pathMapper;
   private final PackageMetadataConfig packageConfig;
+  private final ImportSectionTransformer importSectionTransformer =
+      new RubyImportSectionTransformer();
   private final FileHeaderTransformer fileHeaderTransformer =
-      new FileHeaderTransformer(new RubyImportSectionTransformer());
+      new FileHeaderTransformer(importSectionTransformer);
   private final DynamicLangApiMethodTransformer apiMethodTransformer =
-      new DynamicLangApiMethodTransformer(new RubyApiMethodParamTransformer());
+      new DynamicLangApiMethodTransformer(
+          new RubyApiMethodParamTransformer(), new InitCodeTransformer(importSectionTransformer));
   private final ServiceTransformer serviceTransformer = new ServiceTransformer();
   private final GrpcStubTransformer grpcStubTransformer = new GrpcStubTransformer();
   private final PageStreamingTransformer pageStreamingTransformer = new PageStreamingTransformer();
@@ -93,7 +98,7 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer {
       ModelTypeTable modelTypeTable =
           new ModelTypeTable(
               new RubyTypeTable(apiConfig.getPackageName()),
-              new RubyModelTypeNameConverter(apiConfig.getPackageName()));
+              new RubySampleModelTypeNameConverter(apiConfig.getPackageName()));
       SurfaceTransformerContext context =
           SurfaceTransformerContext.create(
               service, apiConfig, modelTypeTable, namer, featureConfig);

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyPackageMetadataTransformer.java
@@ -113,7 +113,7 @@ public class RubyPackageMetadataTransformer implements ModelToViewTransformer {
         apiConfig,
         new ModelTypeTable(
             new RubyTypeTable(apiConfig.getPackageName()),
-            new RubyModelTypeNameConverter(apiConfig.getPackageName())),
+            new RubySampleModelTypeNameConverter(apiConfig.getPackageName())),
         new RubySurfaceNamer(apiConfig.getPackageName()),
         new RubyFeatureConfig());
   }

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubySampleModelTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubySampleModelTypeNameConverter.java
@@ -1,0 +1,205 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.transformer.ruby;
+
+import com.google.api.codegen.config.FieldConfig;
+import com.google.api.codegen.transformer.ModelTypeNameConverter;
+import com.google.api.codegen.util.NamePath;
+import com.google.api.codegen.util.TypeName;
+import com.google.api.codegen.util.TypeNameConverter;
+import com.google.api.codegen.util.TypedValue;
+import com.google.api.codegen.util.ruby.RubyTypeTable;
+import com.google.api.tools.framework.model.EnumValue;
+import com.google.api.tools.framework.model.ProtoElement;
+import com.google.api.tools.framework.model.TypeRef;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Type;
+import java.util.Arrays;
+import java.util.LinkedList;
+
+public class RubySampleModelTypeNameConverter implements ModelTypeNameConverter {
+
+  /** A map from primitive types to its default value. */
+  private static final ImmutableMap<Type, String> PRIMITIVE_ZERO_VALUE =
+      ImmutableMap.<Type, String>builder()
+          .put(Type.TYPE_BOOL, "false")
+          .put(Type.TYPE_DOUBLE, "0.0")
+          .put(Type.TYPE_FLOAT, "0.0")
+          .put(Type.TYPE_INT64, "0")
+          .put(Type.TYPE_UINT64, "0")
+          .put(Type.TYPE_SINT64, "0")
+          .put(Type.TYPE_FIXED64, "0")
+          .put(Type.TYPE_SFIXED64, "0")
+          .put(Type.TYPE_INT32, "0")
+          .put(Type.TYPE_UINT32, "0")
+          .put(Type.TYPE_SINT32, "0")
+          .put(Type.TYPE_FIXED32, "0")
+          .put(Type.TYPE_SFIXED32, "0")
+          .put(Type.TYPE_STRING, "\'\'")
+          .put(Type.TYPE_BYTES, "\'\'")
+          .build();
+
+  /** A map from primitive type to its corresponding ruby types */
+  private static final ImmutableMap<Type, String> PRIMITIVE_TYPE_MAP =
+      ImmutableMap.<Type, String>builder()
+          .put(Type.TYPE_BOOL, "true, false")
+          .put(Type.TYPE_DOUBLE, "Float")
+          .put(Type.TYPE_FLOAT, "Float")
+          .put(Type.TYPE_INT64, "Integer")
+          .put(Type.TYPE_UINT64, "Integer")
+          .put(Type.TYPE_SINT64, "Integer")
+          .put(Type.TYPE_FIXED64, "Integer")
+          .put(Type.TYPE_SFIXED64, "Integer")
+          .put(Type.TYPE_INT32, "Integer")
+          .put(Type.TYPE_UINT32, "Integer")
+          .put(Type.TYPE_SINT32, "Integer")
+          .put(Type.TYPE_FIXED32, "Integer")
+          .put(Type.TYPE_SFIXED32, "Integer")
+          .put(Type.TYPE_STRING, "String")
+          .put(Type.TYPE_BYTES, "String")
+          .build();
+
+  private TypeNameConverter typeNameConverter;
+
+  public RubySampleModelTypeNameConverter(String implicitPackageName) {
+    this.typeNameConverter = new RubyTypeTable(implicitPackageName);
+  }
+
+  @Override
+  public TypeName getTypeNameInImplicitPackage(String shortName) {
+    return typeNameConverter.getTypeNameInImplicitPackage(shortName);
+  }
+
+  @Override
+  public TypeName getTypeName(TypeRef type) {
+    if (type.isMap()) {
+      return new TypeName("Hash");
+    } else if (type.isRepeated()) {
+      return new TypeName("Array");
+    } else {
+      return getTypeNameForElementType(type);
+    }
+  }
+
+  /**
+   * Returns the Ruby representation of a type. If the type is a primitive,
+   * getTypeNameForElementType returns it in unboxed form.
+   */
+  @Override
+  public TypeName getTypeNameForElementType(TypeRef type) {
+    String primitiveTypeName = PRIMITIVE_TYPE_MAP.get(type.getKind());
+    if (primitiveTypeName != null) {
+      return new TypeName(primitiveTypeName);
+    }
+    switch (type.getKind()) {
+      case TYPE_MESSAGE:
+        return getTypeName(type.getMessageType());
+      case TYPE_ENUM:
+        return getTypeName(type.getEnumType());
+      default:
+        throw new IllegalArgumentException("unknown type kind: " + type.getKind());
+    }
+  }
+
+  @Override
+  public TypeName getTypeName(ProtoElement elem) {
+    String elemName = NamePath.dotted(elem.getFullName()).withUpperPieces().toDoubleColoned();
+    String fullName = elemName;
+    String packageName =
+        NamePath.dotted(elem.getFile().getProto().getPackage()).withUpperPieces().toDoubleColoned();
+    elemName = elemName.replace(packageName, createPackageNickname(packageName));
+    return new TypeName(fullName, elemName);
+  }
+
+  private String createPackageNickname(String packageName) {
+    LinkedList<String> scopeParts = new LinkedList<>(Arrays.asList(packageName.split("::")));
+    StringBuilder nickname = new StringBuilder();
+    for (int i = 0; i < 2 && !scopeParts.isEmpty(); i++) {
+      nickname.insert(0, scopeParts.removeLast());
+    }
+    return nickname.toString();
+  }
+
+  /**
+   * Returns the Ruby representation of a zero value for that type, to be used in code sample doc.
+   */
+  @Override
+  public TypedValue getSnippetZeroValue(TypeRef type) {
+    // Don't call getTypeName; we don't need to import these.
+    if (type.isMap()) {
+      return TypedValue.create(new TypeName("Hash"), "{}");
+    }
+    if (type.isRepeated()) {
+      return TypedValue.create(new TypeName("Array"), "[]");
+    }
+    if (PRIMITIVE_ZERO_VALUE.containsKey(type.getKind())) {
+      return TypedValue.create(getTypeName(type), PRIMITIVE_ZERO_VALUE.get(type.getKind()));
+    }
+    if (type.isMessage()) {
+      return TypedValue.create(getTypeName(type), "%s.new");
+    }
+    if (type.isEnum()) {
+      return getEnumValue(type, type.getEnumType().getValues().get(0));
+    }
+    return TypedValue.create(new TypeName(""), "nil");
+  }
+
+  @Override
+  public TypedValue getImplZeroValue(TypeRef type) {
+    return getSnippetZeroValue(type);
+  }
+
+  @Override
+  public String renderPrimitiveValue(TypeRef type, String value) {
+    Type primitiveType = type.getKind();
+    if (!PRIMITIVE_TYPE_MAP.containsKey(primitiveType)) {
+      throw new IllegalArgumentException(
+          "Initial values are only supported for primitive types, got type "
+              + type
+              + ", with value "
+              + value);
+    }
+    switch (primitiveType) {
+      case TYPE_BOOL:
+        return value.toLowerCase();
+      case TYPE_STRING:
+      case TYPE_BYTES:
+        return "\"" + value + "\"";
+      default:
+        // Types that do not need to be modified (e.g. TYPE_INT32) are handled
+        // here
+        return value;
+    }
+  }
+
+  @Override
+  public TypeName getTypeNameForTypedResourceName(
+      FieldConfig fieldConfig, String typedResourceShortName) {
+    throw new UnsupportedOperationException(
+        "getTypeNameForTypedResourceName not supported by Ruby");
+  }
+
+  @Override
+  public TypeName getTypeNameForResourceNameElementType(
+      FieldConfig fieldConfig, String typedResourceShortName) {
+    throw new UnsupportedOperationException(
+        "getTypeNameForResourceNameElementType not supported by Ruby");
+  }
+
+  @Override
+  public TypedValue getEnumValue(TypeRef type, EnumValue value) {
+    return TypedValue.create(getTypeName(type), "%s::" + value.getSimpleName());
+  }
+}

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
@@ -40,6 +40,8 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 
 /** The SurfaceNamer for Ruby. */
@@ -47,7 +49,7 @@ public class RubySurfaceNamer extends SurfaceNamer {
   public RubySurfaceNamer(String packageName) {
     super(
         new RubyNameFormatter(),
-        new ModelTypeFormatterImpl(new RubyModelTypeNameConverter(packageName)),
+        new ModelTypeFormatterImpl(new RubySampleModelTypeNameConverter(packageName)),
         new RubyTypeTable(packageName),
         new RubyCommentReformatter(),
         packageName);
@@ -264,5 +266,22 @@ public class RubySurfaceNamer extends SurfaceNamer {
       newNames.add(packageFilePathPiece(Name.upperCamel(name)));
     }
     return Joiner.on("/").join(newNames.toArray());
+  }
+
+  @Override
+  public String getPrefixedApiWrapperClassName(InterfaceConfig interfaceConfig) {
+    return getNamespaceNickname(interfaceConfig.getInterface().getFile())
+        + "::"
+        + getApiWrapperClassName(interfaceConfig);
+  }
+
+  @Override
+  public String getNamespaceNickname(ProtoFile file) {
+    LinkedList<String> scopeParts = new LinkedList<>(Arrays.asList(getNamespace(file).split("::")));
+    StringBuilder nickname = new StringBuilder();
+    for (int i = 0; i < 2 && !scopeParts.isEmpty(); i++) {
+      nickname.insert(0, scopeParts.removeLast());
+    }
+    return nickname.toString();
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
@@ -430,11 +430,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #   Shelf = Google::Example::Library::V1::Shelf
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   shelf = Shelf.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   shelf = LibraryV1::Shelf.new
       #   response = library_service_client.create_shelf(shelf)
 
       def create_shelf \
@@ -463,10 +462,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   options_ = ''
       #   response = library_service_client.get_shelf(formatted_name, options_)
 
@@ -499,9 +498,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
       #
       #   # Iterate over all results.
       #   library_service_client.list_shelves.each do |element|
@@ -532,10 +531,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   library_service_client.delete_shelf(formatted_name)
 
       def delete_shelf \
@@ -564,11 +563,11 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
-      #   formatted_other_shelf_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_other_shelf_name = LibraryV1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   response = library_service_client.merge_shelves(formatted_name, formatted_other_shelf_name)
 
       def merge_shelves \
@@ -596,12 +595,11 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   Book = Google::Example::Library::V1::Book
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
-      #   book = Book.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   book = LibraryV1::Book.new
       #   response = library_service_client.create_book(formatted_name, book)
 
       def create_book \
@@ -635,15 +633,13 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #   SeriesUuid = Google::Example::Library::V1::SeriesUuid
-      #   Shelf = Google::Example::Library::V1::Shelf
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   shelf = Shelf.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   shelf = LibraryV1::Shelf.new
       #   books = []
       #   series_string = "foobar"
-      #   series_uuid = SeriesUuid.new
+      #   series_uuid = LibraryV1::SeriesUuid.new
       #   series_uuid.series_string = series_string
       #   response = library_service_client.publish_series(shelf, books, series_uuid)
 
@@ -676,10 +672,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   response = library_service_client.get_book(formatted_name)
 
       def get_book \
@@ -715,10 +711,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #
       #   # Iterate over all results.
       #   library_service_client.list_books(formatted_name).each do |element|
@@ -757,10 +753,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   library_service_client.delete_book(formatted_name)
 
       def delete_book \
@@ -791,12 +787,11 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   Book = Google::Example::Library::V1::Book
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   book = Book.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   book = LibraryV1::Book.new
       #   response = library_service_client.update_book(formatted_name, book)
 
       def update_book \
@@ -828,11 +823,11 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   formatted_other_shelf_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_other_shelf_name = LibraryV1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   response = library_service_client.move_book(formatted_name, formatted_other_shelf_name)
 
       def move_book \
@@ -867,9 +862,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
       #
       #   # Iterate over all results.
       #   library_service_client.list_strings.each do |element|
@@ -906,17 +901,14 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   Alignment = Google::Example::Library::V1::SomeMessage2::SomeMessage3::Alignment
-      #   Comment = Google::Example::Library::V1::Comment
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #   Stage = Google::Example::Library::V1::Comment::Stage
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   comment = ''
-      #   stage = Stage::UNSET
-      #   alignment = Alignment::CHAR
-      #   comments_element = Comment.new
+      #   stage = LibraryV1::Comment::Stage::UNSET
+      #   alignment = LibraryV1::SomeMessage2::SomeMessage3::Alignment::CHAR
+      #   comments_element = LibraryV1::Comment.new
       #   comments_element.comment = comment
       #   comments_element.stage = stage
       #   comments_element.alignment = alignment
@@ -947,10 +939,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK_ID]")
       #   response = library_service_client.get_book_from_archive(formatted_name)
 
       def get_book_from_archive \
@@ -977,11 +969,11 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   formatted_alt_book_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_alt_book_name = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   response = library_service_client.get_book_from_anywhere(formatted_name, formatted_alt_book_name)
 
       def get_book_from_anywhere \
@@ -1010,10 +1002,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   index_name = "default index"
       #   index_map_item = ''
       #   index_map = { "default_key" => index_map_item }
@@ -1046,9 +1038,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
       #   library_service_client.stream_shelves.each do |element|
       #     # Process element.
       #   end
@@ -1073,9 +1065,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
       #   name = ''
       #   library_service_client.stream_books(name).each do |element|
       #     # Process element.
@@ -1111,12 +1103,11 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   DiscussBookRequest = Google::Example::Library::V1::DiscussBookRequest
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
       #   name = ''
-      #   request = DiscussBookRequest.new
+      #   request = LibraryV1::DiscussBookRequest.new
       #   request.name = name
       #   requests = [request]
       #   library_service_client.discuss_book(requests).each do |element|
@@ -1146,12 +1137,11 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   DiscussBookRequest = Google::Example::Library::V1::DiscussBookRequest
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
       #   name = ''
-      #   request = DiscussBookRequest.new
+      #   request = LibraryV1::DiscussBookRequest.new
       #   request.name = name
       #   requests = [request]
       #   response = library_service_client.monolog_about_book(requests)
@@ -1180,9 +1170,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
       #   names_element = ''
       #   names = [names_element]
       #   shelves = []
@@ -1229,10 +1219,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_resource = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_resource = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   tag = ''
       #   response = library_service_client.add_tag(formatted_resource, tag)
 
@@ -1263,10 +1253,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_resource = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_resource = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   label = ''
       #   response = library_service_client.add_label(formatted_resource, label)
 
@@ -1293,10 +1283,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #
       #   # Register a callback during the method call.
       #   operation = library_service_client.get_big_book(formatted_name) do |op|
@@ -1354,10 +1344,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #
       #   # Register a callback during the method call.
       #   operation = library_service_client.get_big_nothing(formatted_name) do |op|
@@ -1459,20 +1449,18 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   InnerEnum = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerEnum
-      #   InnerMessage = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
       #   required_singular_int32 = 0
       #   required_singular_int64 = 0
       #   required_singular_float = 0.0
       #   required_singular_double = 0.0
       #   required_singular_bool = false
-      #   required_singular_enum = InnerEnum::ZERO
+      #   required_singular_enum = LibraryV1::TestOptionalRequiredFlatteningParamsRequest::InnerEnum::ZERO
       #   required_singular_string = ''
       #   required_singular_bytes = ''
-      #   required_singular_message = InnerMessage.new
+      #   required_singular_message = LibraryV1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage.new
       #   required_singular_resource_name = ''
       #   required_singular_resource_name_oneof = ''
       #   required_repeated_int32 = []

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -430,11 +430,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #   Shelf = Google::Example::Library::V1::Shelf
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   shelf = Shelf.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   shelf = LibraryV1::Shelf.new
       #   response = library_service_client.create_shelf(shelf)
 
       def create_shelf \
@@ -463,10 +462,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   options_ = ''
       #   response = library_service_client.get_shelf(formatted_name, options_)
 
@@ -499,9 +498,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
       #
       #   # Iterate over all results.
       #   library_service_client.list_shelves.each do |element|
@@ -532,10 +531,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   library_service_client.delete_shelf(formatted_name)
 
       def delete_shelf \
@@ -564,11 +563,11 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
-      #   formatted_other_shelf_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_other_shelf_name = LibraryV1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   response = library_service_client.merge_shelves(formatted_name, formatted_other_shelf_name)
 
       def merge_shelves \
@@ -596,12 +595,11 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   Book = Google::Example::Library::V1::Book
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
-      #   book = Book.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   book = LibraryV1::Book.new
       #   response = library_service_client.create_book(formatted_name, book)
 
       def create_book \
@@ -635,15 +633,13 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #   SeriesUuid = Google::Example::Library::V1::SeriesUuid
-      #   Shelf = Google::Example::Library::V1::Shelf
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   shelf = Shelf.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   shelf = LibraryV1::Shelf.new
       #   books = []
       #   series_string = "foobar"
-      #   series_uuid = SeriesUuid.new
+      #   series_uuid = LibraryV1::SeriesUuid.new
       #   series_uuid.series_string = series_string
       #   response = library_service_client.publish_series(shelf, books, series_uuid)
 
@@ -676,10 +672,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   response = library_service_client.get_book(formatted_name)
 
       def get_book \
@@ -715,10 +711,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #
       #   # Iterate over all results.
       #   library_service_client.list_books(formatted_name).each do |element|
@@ -757,10 +753,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   library_service_client.delete_book(formatted_name)
 
       def delete_book \
@@ -791,12 +787,11 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   Book = Google::Example::Library::V1::Book
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   book = Book.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   book = LibraryV1::Book.new
       #   response = library_service_client.update_book(formatted_name, book)
 
       def update_book \
@@ -828,11 +823,11 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   formatted_other_shelf_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_other_shelf_name = LibraryV1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   response = library_service_client.move_book(formatted_name, formatted_other_shelf_name)
 
       def move_book \
@@ -867,9 +862,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
       #
       #   # Iterate over all results.
       #   library_service_client.list_strings.each do |element|
@@ -906,17 +901,14 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   Alignment = Google::Example::Library::V1::SomeMessage2::SomeMessage3::Alignment
-      #   Comment = Google::Example::Library::V1::Comment
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #   Stage = Google::Example::Library::V1::Comment::Stage
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   comment = ''
-      #   stage = Stage::UNSET
-      #   alignment = Alignment::CHAR
-      #   comments_element = Comment.new
+      #   stage = LibraryV1::Comment::Stage::UNSET
+      #   alignment = LibraryV1::SomeMessage2::SomeMessage3::Alignment::CHAR
+      #   comments_element = LibraryV1::Comment.new
       #   comments_element.comment = comment
       #   comments_element.stage = stage
       #   comments_element.alignment = alignment
@@ -947,10 +939,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK_ID]")
       #   response = library_service_client.get_book_from_archive(formatted_name)
 
       def get_book_from_archive \
@@ -977,11 +969,11 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   formatted_alt_book_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_alt_book_name = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   response = library_service_client.get_book_from_anywhere(formatted_name, formatted_alt_book_name)
 
       def get_book_from_anywhere \
@@ -1010,10 +1002,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   index_name = "default index"
       #   index_map_item = ''
       #   index_map = { "default_key" => index_map_item }
@@ -1046,9 +1038,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
       #   library_service_client.stream_shelves.each do |element|
       #     # Process element.
       #   end
@@ -1073,9 +1065,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
       #   name = ''
       #   library_service_client.stream_books(name).each do |element|
       #     # Process element.
@@ -1111,12 +1103,11 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   DiscussBookRequest = Google::Example::Library::V1::DiscussBookRequest
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
       #   name = ''
-      #   request = DiscussBookRequest.new
+      #   request = LibraryV1::DiscussBookRequest.new
       #   request.name = name
       #   requests = [request]
       #   library_service_client.discuss_book(requests).each do |element|
@@ -1146,12 +1137,11 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   DiscussBookRequest = Google::Example::Library::V1::DiscussBookRequest
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
       #   name = ''
-      #   request = DiscussBookRequest.new
+      #   request = LibraryV1::DiscussBookRequest.new
       #   request.name = name
       #   requests = [request]
       #   response = library_service_client.monolog_about_book(requests)
@@ -1180,9 +1170,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
       #   names_element = ''
       #   names = [names_element]
       #   shelves = []
@@ -1229,10 +1219,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_resource = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_resource = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   tag = ''
       #   response = library_service_client.add_tag(formatted_resource, tag)
 
@@ -1263,10 +1253,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_resource = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_resource = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   label = ''
       #   response = library_service_client.add_label(formatted_resource, label)
 
@@ -1293,10 +1283,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #
       #   # Register a callback during the method call.
       #   operation = library_service_client.get_big_book(formatted_name) do |op|
@@ -1354,10 +1344,10 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
+      #   formatted_name = LibraryV1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #
       #   # Register a callback during the method call.
       #   operation = library_service_client.get_big_nothing(formatted_name) do |op|
@@ -1459,20 +1449,18 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   InnerEnum = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerEnum
-      #   InnerMessage = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   LibraryV1 = Google::Example::Library::V1
       #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = LibraryV1::LibraryServiceClient.new
       #   required_singular_int32 = 0
       #   required_singular_int64 = 0
       #   required_singular_float = 0.0
       #   required_singular_double = 0.0
       #   required_singular_bool = false
-      #   required_singular_enum = InnerEnum::ZERO
+      #   required_singular_enum = LibraryV1::TestOptionalRequiredFlatteningParamsRequest::InnerEnum::ZERO
       #   required_singular_string = ''
       #   required_singular_bytes = ''
-      #   required_singular_message = InnerMessage.new
+      #   required_singular_message = LibraryV1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage.new
       #   required_singular_resource_name = ''
       #   required_singular_resource_name_oneof = ''
       #   required_repeated_int32 = []

--- a/src/test/java/com/google/api/codegen/testdata/ruby_smoke_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_smoke_test_library.baseline
@@ -26,16 +26,12 @@ describe "LibraryServiceSmokeTest" do
     end
     project_id = ENV["SMOKE_TEST_PROJECT"].freeze
 
-    Book = Google::Example::Library::V1::Book
-    FieldMask = Google::Protobuf::FieldMask
-    LibraryServiceClient = Library::V1::LibraryServiceClient
-    Rating = Google::Example::Library::V1::Book::Rating
-    UpdateBookRequest = Google::Example::Library::V1::UpdateBookRequest
+    LibraryV1 = Google::Example::Library::V1
 
-    library_service_client = LibraryServiceClient.new
-    formatted_name = LibraryServiceClient.book_path("testShelf-" + Time.new.to_i.to_s, project_id)
-    rating = Rating::GOOD
-    book = Book.new
+    library_service_client = LibraryV1::LibraryServiceClient.new
+    formatted_name = LibraryV1::LibraryServiceClient.book_path("testShelf-" + Time.new.to_i.to_s, project_id)
+    rating = LibraryV1::Book::Rating::GOOD
+    book = LibraryV1::Book.new
     book.rating = rating
     response = library_service_client.update_book(formatted_name, book)
   end


### PR DESCRIPTION
This is a proof of concept of changing the aliasing in ruby method samples. The changes to the generator are not ready for prod. This PR is simply to get feedback on the change to the ruby baseline samples.

#### Things left to complete

- [ ] Abstract out the common methods from `RubyModelTypeNameConverter` and `RubySampleModelTypeNameConverter`
- [ ] Create an `AliasSectionView` since the import view doesn't make sense for aliasing types.
- [ ] Disambiguate situations where nicknames can overlap.
- [ ] Have the client load from the packagename not from protofile.